### PR TITLE
Fix portfolio grid alignment for tall items

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,6 +162,7 @@ h4 {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(200px, auto);
     gap: 10px;
     padding: 20px;
 }
@@ -187,7 +188,7 @@ h4 {
 
 .portfolio-item.tall {
     grid-row: span 2;
-    aspect-ratio: 1 / 2;
+    aspect-ratio: unset; /* Let it fill 2 rows naturally, including the gap */
 }
 
 .portfolio-overlay {


### PR DESCRIPTION
- Add explicit grid-auto-rows to portfolio grid
- Remove aspect-ratio constraint from tall items
- Tall items now properly span 2 rows including the gap