### PR TITLE
Fix portfolio grid alignment using grid-auto-rows

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,6 +162,7 @@ h4 {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: minmax(200px, auto);
     gap: 10px;
     padding: 20px;
 }
@@ -187,7 +188,6 @@ h4 {
 
 .portfolio-item.tall {
     grid-row: span 2;
-    aspect-ratio: 1 / 2;
 }
 
 .portfolio-overlay {


### PR DESCRIPTION
Replace aspect-ratio approach with grid-auto-rows for the tall items. This ensures tall items spanning 2 rows align perfectly with the 10px gap, eliminating the 10px misalignment issue.

Changes:
- Add grid-auto-rows: minmax(200px, auto) to .portfolio-grid
- Remove aspect-ratio from .portfolio-item.tall

The grid now properly accounts for gaps between rows, ensuring tall items fill the space of 2 rows + 1 gap perfectly.