### PR TITLE
Remove aspect-ratios and use pure grid control for portfolio items

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,7 +162,7 @@ h4 {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    grid-auto-rows: minmax(200px, auto);
+    grid-auto-rows: 200px;
     gap: 10px;
     padding: 20px;
 }
@@ -172,18 +172,14 @@ h4 {
     overflow: hidden;
     grid-column: span 1;
     grid-row: span 1;
-    aspect-ratio: 1 / 1;
-    min-height: 200px;
 }
 
 .portfolio-item.wide {
     grid-column: span 2;
-    aspect-ratio: 2 / 1;
 }
 
 .portfolio-item.extra-wide {
     grid-column: span 3;
-    aspect-ratio: 3 / 1;
 }
 
 .portfolio-item.tall {


### PR DESCRIPTION
This fixes the grid alignment issues by removing all aspect-ratio properties and letting CSS Grid control sizing entirely.

Changes:
- Changed grid-auto-rows from minmax(200px, auto) to fixed 200px
- Removed aspect-ratio: 1/1 from .portfolio-item
- Removed min-height: 200px from .portfolio-item
- Removed aspect-ratio: 2/1 from .portfolio-item.wide
- Removed aspect-ratio: 3/1 from .portfolio-item.extra-wide

Now the grid purely controls item sizing:
- Default items: 1 column × 1 row (200px tall)
- Wide items: 2 columns × 1 row (200px tall)
- Extra-wide items: 3 columns × 1 row (200px tall)
- Tall items: 1 column × 2 rows (400px tall with 10px gap)

This eliminates conflicts between aspect-ratio and grid-auto-rows and ensures perfect alignment with the 10px gap.