### PR TITLE
Add JavaScript to dynamically set row heights equal to column widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,5 +52,31 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
   });
+
+  // Set grid row height to match column width for perfect squares
+  function setGridRowHeight() {
+    const grid = document.querySelector('.portfolio-grid');
+    if (!grid) return;
+
+    // Calculate column width
+    // Grid has 4 columns, 20px padding on each side, and 10px gaps
+    const gridWidth = grid.clientWidth;
+    const padding = 40; // 20px left + 20px right
+    const gapTotal = 30; // 3 gaps of 10px between 4 columns
+    const columnWidth = (gridWidth - padding - gapTotal) / 4;
+
+    // Set row height to match column width
+    grid.style.gridAutoRows = `${columnWidth}px`;
+  }
+
+  // Set initial row height
+  setGridRowHeight();
+
+  // Update on window resize with debouncing
+  let resizeTimer;
+  window.addEventListener('resize', function() {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(setGridRowHeight, 100);
+  });
 });
 </script>


### PR DESCRIPTION
This ensures perfect grid alignment by making row heights match column widths automatically, regardless of screen size.

Changes:
- Added setGridRowHeight() function that calculates column width based on grid width, padding (40px), and gaps (30px for 3 gaps)
- Calculates: columnWidth = (gridWidth - 40px - 30px) / 4
- Sets grid-auto-rows to the calculated column width dynamically
- Runs on DOMContentLoaded for initial sizing
- Runs on window resize with 100ms debouncing for performance

How it works:
1. JavaScript calculates actual column width from container
2. Sets row height = column width (perfect squares!)
3. 1x1 items are perfectly square
4. 2x1 wide items are perfect 2:1 rectangles
5. Tall items span 2 rows + gap = 2 × columnWidth + 10px (perfect alignment!)

This solves the misalignment issue where rows were inconsistent heights with grid-auto-rows: auto, causing gaps below items.