### PR TITLE
Fix portfolio grid alignment issues

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -227,7 +227,7 @@ h4 {
 .portfolio-thumbnail {
     width: 100%;
     height: 100%;
-    object-fit: fill;
+    object-fit: cover;
     transition: transform 0.2s ease;
     will-change: transform;
 }
@@ -238,7 +238,7 @@ h4 {
 
 /* Video thumbnails */
 .portfolio-item video.portfolio-thumbnail {
-    object-fit: fill;
+    object-fit: cover;
 }
 
 /* ===== PORTFOLIO ITEM PAGE ===== */


### PR DESCRIPTION
Previously using object-fit: fill was distorting images. Changed to cover to maintain aspect ratios while filling containers.