### PR TITLE
Revert to PR #7 state - Remove aspect-ratios and use pure grid control

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,10 +162,9 @@ h4 {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    grid-auto-rows: auto;
+    grid-auto-rows: 200px;
     gap: 10px;
     padding: 20px;
-    align-items: stretch;
 }
 
 .portfolio-item {
@@ -173,31 +172,18 @@ h4 {
     overflow: hidden;
     grid-column: span 1;
     grid-row: span 1;
-    aspect-ratio: 1 / 1;
-    align-self: stretch;
-    display: flex;
-}
-
-.portfolio-item .portfolio-link {
-    width: 100%;
-    height: 100%;
-    display: block;
 }
 
 .portfolio-item.wide {
     grid-column: span 2;
-    aspect-ratio: 2 / 1;
 }
 
 .portfolio-item.extra-wide {
     grid-column: span 3;
-    aspect-ratio: 3 / 1;
 }
 
 .portfolio-item.tall {
     grid-row: span 2;
-    aspect-ratio: auto;
-    height: 100%;
 }
 
 .portfolio-overlay {


### PR DESCRIPTION
Reverting back to the grid approach from PR #7 which used grid-auto-rows with a fixed 200px height and simple grid span controls without aspect-ratios.