### PR TITLE
Fix portfolio grid layout with proper auto-grid system

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,8 +162,10 @@ h4 {
 .portfolio-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+    grid-auto-rows: 200px;
     gap: 10px;
     padding: 20px;
+    grid-auto-flow: dense;
 }
 
 .portfolio-item {
@@ -171,23 +173,19 @@ h4 {
     overflow: hidden;
     grid-column: span 1;
     grid-row: span 1;
-    aspect-ratio: 1 / 1;
-    min-height: 200px;
+    background-color: #1a1a1a;
 }
 
 .portfolio-item.wide {
     grid-column: span 2;
-    aspect-ratio: 2 / 1;
 }
 
 .portfolio-item.extra-wide {
     grid-column: span 3;
-    aspect-ratio: 3 / 1;
 }
 
 .portfolio-item.tall {
     grid-row: span 2;
-    aspect-ratio: 1 / 2;
 }
 
 .portfolio-overlay {
@@ -217,7 +215,7 @@ h4 {
 .portfolio-thumbnail {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     transition: transform 0.2s ease;
     will-change: transform;
 }
@@ -228,7 +226,7 @@ h4 {
 
 /* Video thumbnails */
 .portfolio-item video.portfolio-thumbnail {
-    object-fit: cover;
+    object-fit: contain;
 }
 
 /* ===== PORTFOLIO ITEM PAGE ===== */


### PR DESCRIPTION
Replace aspect-ratio approach with grid-auto-rows for consistent spacing:
- Use grid-auto-rows: 200px with explicit row/column spans
- Remove aspect-ratio properties that didn't account for 10px gaps
- Change object-fit from cover to contain to prevent thumbnail cropping
- Add grid-auto-flow: dense for better space utilization
- Add background-color to portfolio items for better presentation

This professional approach ensures:
- Consistent 10px gaps between all rows and columns
- No extra spacing below tall items
- No cropped thumbnails
- More maintainable and predictable grid behavior