### PR TITLE
Fix grid layout spacing by adjusting aspect-ratios to account for gaps

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -172,22 +172,21 @@ h4 {
     grid-column: span 1;
     grid-row: span 1;
     aspect-ratio: 1 / 1;
-    min-height: 200px;
 }
 
 .portfolio-item.wide {
     grid-column: span 2;
-    aspect-ratio: 2 / 1;
+    aspect-ratio: 21 / 10;  /* Accounts for 1 gap between 2 columns */
 }
 
 .portfolio-item.extra-wide {
     grid-column: span 3;
-    aspect-ratio: 3 / 1;
+    aspect-ratio: 16 / 5;  /* Accounts for 2 gaps between 3 columns */
 }
 
 .portfolio-item.tall {
     grid-row: span 2;
-    aspect-ratio: 1 / 2;
+    aspect-ratio: 10 / 21;  /* Accounts for 1 gap between 2 rows */
 }
 
 .portfolio-overlay {


### PR DESCRIPTION
- Remove min-height constraint that was causing extra vertical space
- Update aspect-ratios to account for 10px gaps between grid cells
- Wide items: 2/1 → 21/10 (2 columns + 1 gap)
- Extra-wide items: 3/1 → 16/5 (3 columns + 2 gaps)
- Tall items: 1/2 → 10/21 (2 rows + 1 gap)
- Grid cells now align perfectly with no extra space