### PR TITLE
Update image source to use full_image if available

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -44,7 +44,7 @@ layout: default
 
   <div class="portfolio-image">
     <img id="zoomable-image"
-         src="{{ page.thumbnail }}"
+         src="{{ page.full_image | default: page.thumbnail }}"
          alt="{{ page.title }}"
          data-full-image="{{ page.full_image | default: page.thumbnail }}"
          {% if page.storymap_url %}data-storymap-url="{{ page.storymap_url }}"{% endif %}>


### PR DESCRIPTION
portfolio pages should now show the full scale image instead of the thumbnail