### PR TITLE
Add support for separate page_image in portfolio items

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -44,7 +44,7 @@ layout: default
 
   <div class="portfolio-image">
     <img id="zoomable-image"
-         src="{{ page.thumbnail }}"
+         src="{{ page.page_image | default: page.full_image | default: page.thumbnail }}"
          alt="{{ page.title }}"
          data-full-image="{{ page.full_image | default: page.thumbnail }}"
          {% if page.storymap_url %}data-storymap-url="{{ page.storymap_url }}"{% endif %}>


### PR DESCRIPTION
Updates portfolio item layout to support three distinct image types:
- thumbnail: for portfolio grid view
- page_image: for portfolio item page display (new)
- full_image: for zoom popup

Uses fallback logic: page_image -> full_image -> thumbnail Maintains backward compatibility with existing portfolio items.