### PR TITLE
Add contact page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (231)
@@ -224,6 +225,8 @@ GEM
       uri
     nokogiri (1.16.5-x64-mingw-ucrt)
       racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -263,6 +266,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   github-pages

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -344,6 +344,120 @@ h4 {
     text-decoration: none;
 }
 
+/* ===== CONTACT PAGE STYLES ===== */
+.contact-page {
+    padding: 40px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.contact-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 60px;
+    align-items: start;
+    position: relative;
+}
+
+/* Red divider line between columns */
+.contact-container::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1px;
+    background-color: #f00;
+}
+
+.contact-info h1 {
+    font-size: 48px;
+    font-weight: 300;
+    margin-bottom: 30px;
+    color: white;
+}
+
+.contact-info p {
+    font-size: 16px;
+    line-height: 1.8;
+    color: #ddd;
+    margin-bottom: 20px;
+}
+
+.contact-form-wrapper {
+    padding-left: 20px;
+}
+
+/* Form Styles */
+.form-group {
+    margin-bottom: 25px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    color: white;
+    font-size: 14px;
+    font-weight: 400;
+}
+
+.form-group input,
+.form-group textarea {
+    width: 100%;
+    padding: 12px 15px;
+    background-color: #222;
+    border: 1px solid #555;
+    color: white;
+    font-family: 'Helvetica', sans-serif;
+    font-size: 14px;
+    border-radius: 2px;
+    transition: border-color 0.3s ease;
+    box-sizing: border-box;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: #f00;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 150px;
+}
+
+.submit-btn {
+    background-color: #f00;
+    color: white;
+    border: none;
+    padding: 14px 40px;
+    font-size: 16px;
+    font-family: 'Helvetica', sans-serif;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    border-radius: 2px;
+    font-weight: 400;
+}
+
+.submit-btn:hover {
+    background-color: #cc0000;
+}
+
+.success-message {
+    padding: 30px;
+    background-color: #1a4d1a;
+    border: 1px solid #2d7a2d;
+    border-radius: 4px;
+    text-align: center;
+}
+
+.success-message p {
+    color: #90ee90;
+    font-size: 18px;
+    margin: 0;
+}
+
 /* ===== PORTFOLIO NAVIGATION ARROWS ===== */
 .portfolio-nav {
     position: fixed;
@@ -535,6 +649,32 @@ h4 {
         top: 10px;
         right: 20px;
         font-size: 30px;
+    }
+
+    /* Contact Page Mobile Styles */
+    .contact-page {
+        padding: 20px;
+    }
+
+    .contact-container {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+
+    .contact-container::after {
+        display: none;
+    }
+
+    .contact-info h1 {
+        font-size: 36px;
+    }
+
+    .contact-form-wrapper {
+        padding-left: 0;
+    }
+
+    .submit-btn {
+        width: 100%;
     }
 }
 

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Contact
+---
+
+<div class="contact-page">
+  <div class="contact-container">
+    <div class="contact-info">
+      <h1>Contact Me</h1>
+      <p>I'm always interested in hearing about new opportunities in GIS, cartography, and spatial analysis. Whether you're looking for a skilled technician to join your team or need consultation on a mapping project, I'd love to hear from you.</p>
+      <p>Please fill out the form and I'll get back to you as soon as possible.</p>
+    </div>
+
+    <div class="contact-form-wrapper">
+      <form id="contact-form" action="https://formspree.io/f/nathan.duggins@gmail.com" method="POST">
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" required>
+        </div>
+
+        <div class="form-group">
+          <label for="company">Company</label>
+          <input type="text" id="company" name="company">
+        </div>
+
+        <div class="form-group">
+          <label for="email">Email Address</label>
+          <input type="email" id="email" name="_replyto" required>
+        </div>
+
+        <div class="form-group">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" rows="8" required></textarea>
+        </div>
+
+        <input type="hidden" name="_subject" value="New contact form submission from nathanduggins.com">
+
+        <button type="submit" class="submit-btn">Send Message</button>
+      </form>
+
+      <div id="success-message" class="success-message" style="display: none;">
+        <p>Thank you for your message! I'll get back to you soon.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('contact-form');
+  const successMessage = document.getElementById('success-message');
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+
+    // Get form data
+    const formData = new FormData(form);
+
+    // Send to Formspree
+    fetch(form.action, {
+      method: 'POST',
+      body: formData,
+      headers: {
+        'Accept': 'application/json'
+      }
+    })
+    .then(response => {
+      if (response.ok) {
+        // Clear form
+        form.reset();
+
+        // Show success message
+        form.style.display = 'none';
+        successMessage.style.display = 'block';
+
+        // Reset after 5 seconds
+        setTimeout(function() {
+          form.style.display = 'block';
+          successMessage.style.display = 'none';
+        }, 5000);
+      } else {
+        response.json().then(data => {
+          if (Object.hasOwn(data, 'errors')) {
+            alert(data.errors.map(error => error.message).join(', '));
+          } else {
+            alert('Oops! There was a problem submitting your form');
+          }
+        });
+      }
+    })
+    .catch(error => {
+      alert('Oops! There was a problem submitting your form');
+    });
+  });
+});
+</script>


### PR DESCRIPTION
- Created contact.html with two-column layout matching portfolio aesthetic
- Left column: "Contact Me" heading with professional paragraph for employers
- Right column: Contact form with name, company, email, and message fields
- Integrated Formspree for email delivery to nathan.duggins@gmail.com
- Added red accent line divider matching portfolio page styling
- Implemented form clearing after successful submission
- Added success message display after form submission
- Ensured full mobile responsiveness with single-column stack on mobile
- Styled inputs and textarea with dark theme (#333 bg, #f00 accents)
- Added hover effects and focus states for better UX
- Updated Gemfile.lock with bundle install