### PR TITLE
Add honeypot spam protection to contact form

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -499,6 +499,15 @@ h4 {
     border-color: #ff6b6b;
 }
 
+/* Honeypot spam protection - hidden from humans */
+.honeypot {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
 /* ===== PORTFOLIO NAVIGATION ARROWS ===== */
 .portfolio-nav {
     position: fixed;

--- a/contact.html
+++ b/contact.html
@@ -35,6 +35,12 @@ permalink: /contact/
           <textarea id="message" name="message" rows="8" required></textarea>
         </div>
 
+        <!-- Honeypot field - hidden from humans, visible to bots -->
+        <div class="honeypot">
+          <label for="website">Website</label>
+          <input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+        </div>
+
         <input type="hidden" name="_subject" value="New contact form submission from nathanduggins.com">
 
         <button type="submit" class="submit-btn">Send Message</button>
@@ -92,6 +98,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
   form.addEventListener('submit', function(e) {
     e.preventDefault();
+
+    // Check honeypot - if filled, it's a bot
+    const honeypot = document.getElementById('website');
+    if (honeypot.value) {
+      // Silently reject spam - don't send anything
+      console.log('Spam detected via honeypot');
+      return;
+    }
 
     // Validate email before submitting
     if (!validateEmail(emailInput.value)) {


### PR DESCRIPTION
- Add invisible 'website' field that only bots will fill out
- Position honeypot field off-screen using CSS (invisible to humans)
- Silently reject submissions if honeypot is filled
- Protects 50-message Formspree limit from spam bots
- No visual or UX impact on legitimate users