### PR TITLE
Add max-height constraint to portfolio images

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -89,6 +89,7 @@ layout: default
 
   .portfolio-image img {
     max-width: 100%;
+    max-height: 80vh;
     height: auto;
     object-fit: contain;
     cursor: pointer;


### PR DESCRIPTION
Implements viewport-based max-height (80vh) to prevent tall images like the REM poster from extending beyond the viewport and pushing centered text too far down the page. Maintains aspect ratio and responsiveness across all screen sizes.