### PR TITLE
Reduce max-height to 70vh for more conservative image sizing

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -89,7 +89,7 @@ layout: default
 
   .portfolio-image img {
     max-width: 100%;
-    max-height: 80vh;
+    max-height: 70vh;
     height: auto;
     object-fit: contain;
     cursor: pointer;


### PR DESCRIPTION
Adjusts portfolio image constraint from 80vh to 70vh to provide more balanced layout and ensure text remains prominently visible.