### PR TITLE
Reduce max-height to 60vh for optimal image sizing

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -89,7 +89,7 @@ layout: default
 
   .portfolio-image img {
     max-width: 100%;
-    max-height: 70vh;
+    max-height: 60vh;
     height: auto;
     object-fit: contain;
     cursor: pointer;


### PR DESCRIPTION
Further adjusts portfolio image constraint to 60vh to ensure better balance between image prominence and text visibility.