### PR TITLE
Improve tone and spacing in employment section

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -116,9 +116,9 @@ permalink: /resume/
 
             <h4>GIS Quality Assurance – CACI International Inc.</h4>
             <span class="job-date">August 2021 – Present</span>
-            <p>Support federal intelligence operations through geospatial product quality assurance, production workflows, and team collaboration. Contribute to automation initiatives and analyst development while maintaining production standards and client deliverable requirements.</p>
+            <p>I perform quality assurance on geospatial datasets for federal intelligence clients, ensuring satellite imagery products meet accuracy standards. I develop Python automation tools that streamline team workflows and mentor junior analysts on imagery interpretation and quality control procedures.</p>
             <ul>
-                <li>Execute quality control procedures on digitized geospatial features including buildings, roads, infrastructure, and terrain annotations supporting national security operations</li>
+                <li>Execute quality control procedures on digitized geospatial features including buildings, roads, infrastructure, and terrain annotations for federal intelligence agencies</li>
                 <li>Develop Python automation scripts streamlining digitization workflows, reducing manual processing time and improving production efficiency across multi-analyst teams</li>
                 <li>Implement automated quality control tools to identify topology errors, attribute inconsistencies, and geometric anomalies in large-scale geospatial datasets</li>
                 <li>Mentor junior imagery analysts on satellite imagery interpretation techniques, quality control procedures, and intelligence community production standards</li>
@@ -127,12 +127,13 @@ permalink: /resume/
                 <li>Track quality metrics and production statistics supporting performance monitoring and project reporting</li>
                 <li>Execute rework and correction tasks on products returned from client review, incorporating feedback and ensuring revised deliverables meet updated specifications</li>
             </ul>
+            <br>
 
             <h4>Owner/Pilot – Levitate Drones</h4>
             <span class="job-date">December 2016 – Present</span>
             <p>Founded and operate a specialized UAV services company providing high-precision geospatial data products to federal agencies and research organizations. Build client relationships, execute field operations, and deliver scientific-grade mapping products for environmental research applications.</p>
             <ul>
-                <li>Built client portfolio serving National Park Service, university research programs, and municipal agencies for ecological monitoring and post-disaster assessment projects</li>
+                <li>Provide mapping services to National Park Service, university research programs, and municipal agencies for ecological monitoring and post-disaster assessment projects</li>
                 <li>Planned and executed UAV missions across diverse environments including coastal zones, riparian corridors, and urban-wildland interfaces</li>
                 <li>Produced orthomosaics, elevation models, and multispectral imagery products meeting scientific research standards for peer-reviewed studies</li>
                 <li>Processed thousands of aerial images into georeferenced data products using Agisoft Metashape and Pix4D photogrammetry software</li>
@@ -145,6 +146,7 @@ permalink: /resume/
                 <li>Provided GIS-compatible deliverables integrated with client databases for ongoing monitoring and comparative analysis</li>
                 <li>Communicated technical workflows and data quality considerations to researchers from ecology, geology, and engineering disciplines</li>
             </ul>
+            <br>
 
             <h4>Store Manager – FedEx Office</h4>
             <span class="job-date">June 2008 – January 2017</span>
@@ -161,6 +163,7 @@ permalink: /resume/
                 <li>Analyzed operational data identifying performance trends and implementing corrective actions to improve outcomes</li>
             </ul>
         </section>
+        <br>
 
         <section>
             <h3><u>Education</u></h3>
@@ -168,6 +171,7 @@ permalink: /resume/
             <p>Front Range Community College – Boulder, Colorado</p>
             <p>Summa Cum Laude – Focus on GIS and Remote Sensing</p>
         </section>
+        <br>
 
         <section>
             <h3><u>Certifications</u></h3>


### PR DESCRIPTION
- Rewrote CACI overview to sound more natural and personable while maintaining professionalism
- Changed "national security operations" to "federal intelligence agencies" in first CACI bullet
- Changed "Built client portfolio" to "Provide mapping services to" in Levitate Drones section
- Added visual spacing between job entries in Employment History section
- Added spacing between Employment History, Education, and Certifications sections for better visual balance