### PR TITLE
Add portfolio links to Practical Field Projects

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -188,7 +188,7 @@ permalink: /resume/
 <section class="projects-section">
     <h3><u>Practical Field Projects</u></h3>
     <h4>Multispectral Intertidal Ecosystem Mapping – Point Reyes, CA</h4>
-    <p>I collaborated with National Park Service researchers on a multispectral UAV mapping project to document and classify intertidal habitats along the Point Reyes coastline. The work established high-resolution baseline data to support long-term ecological monitoring and climate change studies.</p>
+    <p>I collaborated with National Park Service researchers on a multispectral UAV mapping project to document and classify intertidal habitats along the Point Reyes coastline. The work established high-resolution baseline data to support long-term ecological monitoring and climate change studies. <a href="/portfolio/2-point-reyes/" target="_blank" rel="noopener noreferrer">View full project details →</a></p>
     <ul>
         <li>Conducted multispectral UAV surveys across four beach sites during the year's lowest tides, capturing imagery for ecological analysis.</li>
         <li>Managed full UAV workflow: preflight planning around tidal windows, field operations, and post-processing.</li>
@@ -201,7 +201,7 @@ permalink: /resume/
     <br>
 
     <h4>Automated Flood Extents Using Synthetic Aperture Radar (SAR) - Google Earth Engine</h4>
-    <p>I developed an automated flood mapping workflow in Google Earth Engine to support rapid disaster response where cloud cover limits optical imagery and traditional SAR methods depend on slow, manual training data. The system leverages Sentinel-1 radar and unsupervised classification to deliver fast, accurate flood detection.</p>
+    <p>I developed an automated flood mapping workflow in Google Earth Engine to support rapid disaster response where cloud cover limits optical imagery and traditional SAR methods depend on slow, manual training data. The system leverages Sentinel-1 radar and unsupervised classification to deliver fast, accurate flood detection. <a href="/portfolio/3-sar-poster/" target="_blank" rel="noopener noreferrer">View full project details →</a></p>
     <ul>
         <li>Built an unsupervised K-means classification workflow based on Sentinel-1 SAR data from Hurricane Harvey's impact on Harris County, Texas.</li>
         <li>Applied SAR polarization band math using VV, VH, and derived composites (VH+VV, VH/VV, etc.) to enhance water-surface separability.</li>
@@ -216,7 +216,7 @@ permalink: /resume/
     <br>
 
     <h4>Ecological Post-Disaster Reconstruction Assessment - St. Vrain Creek</h4>
-    <p>I partnered with University of Northern Colorado researchers and the city of Longmont to assess post-flood reconstruction along the St. Vrain Creek following the 2013 disaster. The project established high-accuracy geospatial baselines to compare human-centered redevelopment and ecologically focused restoration strategies across the watershed.</p>
+    <p>I partnered with University of Northern Colorado researchers and the city of Longmont to assess post-flood reconstruction along the St. Vrain Creek following the 2013 disaster. The project established high-accuracy geospatial baselines to compare human-centered redevelopment and ecologically focused restoration strategies across the watershed. <a href="/portfolio/4-dickens/" target="_blank" rel="noopener noreferrer">View full project details →</a></p>
     <ul>
         <li>Conducted multispectral UAV surveys over a 2.25-mile stretch of the St. Vrain Creek corridor, including the Dicken's Farm Nature Area and adjacent restoration zones.</li>
         <li>Managed complete UAV workflow: mission planning, flight operations, data acquisition, and post-processing.</li>


### PR DESCRIPTION
- Added inline links at the end of each project description paragraph
- Links open in new tab (target="_blank") allowing users to explore details while keeping resume page accessible
- Included rel="noopener noreferrer" for security best practices
- Linked to corresponding portfolio pages:
  - Point Reyes → /portfolio/2-point-reyes/
  - SAR Flood Detection → /portfolio/3-sar-poster/
  - St. Vrain Creek → /portfolio/4-dickens/
- Maintains clean, professional aesthetic with subtle "View full project details →" call-to-action