### PR TITLE
Streamline Skills section by removing redundant bullets

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -21,7 +21,6 @@ permalink: /resume/
                 <li>Executed viewshed analysis and line-of-sight modeling for telecommunications tower placement and visual impact assessments</li>
                 <li>Conducted cost-distance analysis and least-cost path routing to identify optimal corridor locations while minimizing environmental impact</li>
                 <li>Executed coordinate system transformations and projection management ensuring geometric accuracy across multi-source datasets spanning different spatial reference systems</li>
-                <li>Applied buffer analysis and proximity modeling to assess spatial relationships between environmental features and human infrastructure</li>
                 <li>Developed raster analysis workflows using map algebra operations for land suitability modeling and environmental change detection</li>
                 <li>Conducted time-series spatial analysis tracking temporal changes in land use patterns and environmental conditions</li>
                 <li>Applied vector data analysis techniques including spatial joins, relationship classes, and geometric calculations for feature attribution and spatial relationship assessment</li>
@@ -46,12 +45,10 @@ permalink: /resume/
                 <li>Performed point cloud classification and segmentation using machine learning algorithms extracting terrain, vegetation, and infrastructure features from dense point clouds</li>
                 <li>Generated high-accuracy digital elevation models (DEMs) and digital surface models (DSMs) using cloth simulation filtering (CSF) algorithms in cloudCompare for flood assessment and hydrological modeling</li>
                 <li>Conducted dense point cloud generation and filtering producing millions of 3D points per project for detailed topographic reconstruction</li>
-                <li>Performed tie point optimization and image alignment procedures maximizing overlap and minimizing reprojection errors</li>
                 <li>Executed ground point classification and bare earth extraction separating terrain from above-ground features</li>
                 <li>Conducted photogrammetric accuracy assessment comparing ground control point coordinates with model-derived values</li>
                 <li>Applied point cloud noise filtering and outlier removal techniques improving data quality for subsequent classification</li>
                 <li>Generated cross-sections and profile analyses from point cloud data supporting infrastructure design and monitoring</li>
-                <li>Performed point cloud colorization applying RGB values from imagery for enhanced visualization</li>
                 <li>Developed post-processing workflows optimizing computational efficiency while maintaining geometric accuracy</li>
             </ul>
             <h4>Programming & Automation</h4>


### PR DESCRIPTION
Removed three bullet points to reduce redundancy and focus on core competencies:
- Removed "Applied buffer analysis and proximity modeling..." from GIS Analysis (redundant with line 18)
- Removed "Performed tie point optimization..." from Photogrammetry (sub-step already implied in complete workflows)
- Removed "Performed point cloud colorization..." from Photogrammetry (visualization enhancement, less critical than other skills)

Skills section now more concise while maintaining comprehensive coverage of all key competencies.