### PR TITLE
Personalize portfolio items and add project-specific bullets

### DIFF
--- a/_portfolio/1_rem.md
+++ b/_portfolio/1_rem.md
@@ -7,10 +7,9 @@ short_description: Waimakairiri River, New Zealand
 size: extra-wide
 ---
 
-## Relative Elevation Model (REM) Development – QGIS
+I developed a Relative Elevation Model (REM) workflow in QGIS that transforms standard elevation data into a surface showing height relative to the active river channel. By setting the river level to zero and displaying surrounding terrain as positive values above water, I revealed subtle floodplain features like paleochannels, levees, and terraces that are difficult to interpret from conventional topographic maps, providing essential data for river restoration planning and floodplain management.
 
-Relative Elevation Models (REMs) transform standard elevation data into surfaces that show height relative to the active river channel, making subtle floodplain features like paleochannels, levees, and terraces immediately visible. By setting the current river level to zero and displaying surrounding terrain as positive values above water, REMs reveal geomorphic patterns and flood-prone areas that are difficult to interpret from conventional topographic maps, providing essential data for river restoration planning and floodplain management.
-
+- Developed workflow for the Waimakairiri River in New Zealand, revealing historical channel migrations and geomorphic evolution patterns across the braided river system
 - Processed bare-earth DEMs and densified river centerlines to 10-30m vertex spacing, sampling elevations to create high-density water surface elevation profiles
 - Applied IDW interpolation (power: 2.0, 16-24 nearest points) to generate smooth water surface models, then subtracted from DEMs using raster calculator to produce relative elevation surfaces
 - Masked outputs to floodplain extents and validated against aerial imagery confirming accurate representation of bars, levees, and paleochannels

--- a/_portfolio/2__point_reyes.md
+++ b/_portfolio/2__point_reyes.md
@@ -10,9 +10,7 @@ size: tall
 storymap_url: https://storymaps.arcgis.com/stories/a2265baddeef4e33829617c9d7542329
 ---
 
-## Multispectral Intertidal Ecosystem Mapping – Point Reyes, CA
-
-Multispectral UAV mapping combines aerial imagery across multiple spectral bands to distinguish vegetation types, substrate compositions, and ecological features that appear similar in standard RGB photography. This technique is particularly valuable for coastal ecosystem monitoring where precise species classification and habitat mapping support long-term ecological research and inform conservation management decisions.
+I used multispectral UAV mapping to capture aerial imagery across multiple spectral bands, distinguishing vegetation types and substrate compositions that appear identical in standard RGB photography. This approach provided the National Park Service with precise species classification and habitat mapping supporting their long-term ecological monitoring and conservation management efforts along the Point Reyes coastline.
 
 - Conducted multispectral UAV surveys across four beach sites during the year's lowest tides, capturing imagery for ecological analysis.
 - Managed full UAV workflow: preflight planning around tidal windows, field operations, and post-processing.

--- a/_portfolio/3_SAR_Poster.md
+++ b/_portfolio/3_SAR_Poster.md
@@ -7,11 +7,10 @@ short_description: Google Earth Engine (GEE)
 size: wide
 ---
 
-## Automated Flood Extents Using Synthetic Aperture Radar (SAR) - Google Earth Engine
+I developed an automated SAR flood mapping workflow to overcome the limitations of traditional methods that require slow manual training data collection. By leveraging radar signals that penetrate cloud cover and implementing unsupervised classification in Google Earth Engine, I created a system that rapidly generates flood maps without human intervention, enabling faster deployment for disaster management when optical imagery is unavailable.
 
-Synthetic Aperture Radar (SAR) flood mapping uses radar signals that penetrate cloud cover to detect water extents during disaster events when optical satellite imagery is unavailable. Traditional SAR methods require manual training data collection that delays emergency response, while automated approaches using unsupervised classification can rapidly generate flood maps without human intervention, enabling faster deployment for disaster management.
-
-- Developed unsupervised K-means classification workflow in Google Earth Engine using Sentinel-1 SAR data from Hurricane Harvey, reducing setup to two user-adjustable parameters for rapid emergency deployment
+- Developed unsupervised K-means classification workflow in Google Earth Engine using Sentinel-1 SAR data, reducing setup to two user-adjustable parameters for rapid emergency deployment
+- Tested workflow on Hurricane Harvey flooding in Harris County, Texas, demonstrating cloud-penetrating SAR capabilities where optical imagery remained obscured during recovery operations
 - Applied SAR polarization band math (VV, VH, derived composites) with adaptive 50m speckle filtering to enhance water-surface detection while preserving hydrological feature boundaries
 - Achieved 89% classification accuracy without human-labeled training data, exceeding supervised methods by ~11 percentage points
 - Designed globally scalable architecture enabling rapid application to any flood event or watershed without site-specific retraining

--- a/_portfolio/4_dickens.md
+++ b/_portfolio/4_dickens.md
@@ -7,14 +7,13 @@ short_description: Longmont, CO
 size:
 ---
 
-## Ecological Post-Disaster Reconstruction Assessment - St. Vrain Creek
+I partnered with University of Northern Colorado researchers and the city of Longmont to conduct a post-disaster reconstruction assessment of the St. Vrain Creek using high-resolution geospatial data. This work established baseline datasets comparing human-centered infrastructure redevelopment against ecologically focused habitat restoration, providing quantitative evidence to guide future disaster recovery planning in the watershed following the 2013 flood.
 
-Post-disaster reconstruction assessments use high-resolution geospatial data to document landscape conditions following catastrophic events, establishing baseline datasets that enable researchers to evaluate recovery strategies and guide future planning. These assessments compare different reconstruction approaches—from human-centered infrastructure redevelopment to ecologically focused habitat restoration—providing quantitative evidence for long-term decision-making in disaster-prone watersheds.
-
-- Conducted multispectral UAV surveys over a 2.25-mile stretch of the St. Vrain Creek corridor, including the Dicken's Farm Nature Area and adjacent restoration zones.
-- Managed complete UAV workflow: mission planning, flight operations, data acquisition, and post-processing.
-- Used a Trimble R10 GNSS to establish centimeter-accurate ground control for long-term monitoring precision.
-- Produced high-resolution orthophotos, digital elevation models (DEMs), NDVI layers, and classified point clouds for quantitative habitat and landform analysis using Agisoft Metashape and CloudCompare.
-- Collaborated with multiple stakeholders to ensure the mapping products met both ecological research goals and municipal planning needs.
-- Delivered datasets now serving as baseline monitoring data for evaluating ecological recovery and reconstruction outcomes.
-- Provided a comparative framework enabling researchers to measure long-term ecological success and guide future riparian restoration and disaster-recovery planning.
+- Conducted multispectral UAV surveys over a 2.25-mile stretch of the St. Vrain Creek corridor, including the Dicken's Farm Nature Area and adjacent restoration zones
+- Mapped both human-centered redevelopment areas and ecologically focused restoration zones, enabling direct comparison of recovery strategies across the watershed
+- Managed complete UAV workflow: mission planning, flight operations, data acquisition, and post-processing
+- Used a Trimble R10 GNSS to establish centimeter-accurate ground control for long-term monitoring precision
+- Produced high-resolution orthophotos, digital elevation models (DEMs), NDVI layers, and classified point clouds for quantitative habitat and landform analysis using Agisoft Metashape and CloudCompare
+- Collaborated with multiple stakeholders to ensure the mapping products met both ecological research goals and municipal planning needs
+- Delivered datasets now serving as baseline monitoring data for evaluating ecological recovery and reconstruction outcomes
+- Provided a comparative framework enabling researchers to measure long-term ecological success and guide future riparian restoration and disaster-recovery planning


### PR DESCRIPTION
All Portfolio Items:
- Removed h2 headers (redundant with title metadata)
- Rewrote paragraphs to show personal ownership using "I developed/used/partnered" language
- Maintains technical explanations while clearly attributing work

Point Reyes:
- Paragraph now emphasizes personal use of multispectral UAV mapping to serve National Park Service
- No new bullets added (already had appropriate length)

SAR Flood Detection:
- Paragraph highlights personal development of automated workflow overcoming traditional method limitations
- Added bullet: "Tested workflow on Hurricane Harvey flooding in Harris County, Texas, demonstrating cloud-penetrating SAR capabilities where optical imagery remained obscured during recovery operations"

St. Vrain Creek:
- Paragraph emphasizes partnership with UNC researchers and city of Longmont
- Added bullet: "Mapped both human-centered redevelopment areas and ecologically focused restoration zones, enabling direct comparison of recovery strategies across the watershed"

REM:
- Paragraph shows personal workflow development in QGIS revealing floodplain features
- Added bullet: "Developed workflow for the Waimakairiri River in New Zealand, revealing historical channel migrations and geomorphic evolution patterns across the braided river system"

Result: Portfolio items now clearly communicate personal contributions while maintaining technical depth and educational value.