### PR TITLE
Improve mobile portfolio layout with text under images and red dividers

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -629,9 +629,17 @@ h4 {
 
     .portfolio-item {
         width: 100%;
-        aspect-ratio: 16 / 9;
+        display: flex;
+        flex-direction: column;
         position: relative;
-        overflow: hidden;
+        padding-bottom: 30px;
+        border-bottom: 2px solid #f00;
+    }
+
+    /* Remove the border from the last item */
+    .portfolio-item:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
     }
 
     /* Remove pseudo-element on mobile */
@@ -643,25 +651,38 @@ h4 {
     .portfolio-item > .portfolio-link {
         position: relative;
         width: 100%;
-        height: 100%;
+        aspect-ratio: 16 / 9;
+        overflow: hidden;
     }
 
     .portfolio-item.wide,
     .portfolio-item.extra-wide,
     .portfolio-item.tall {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .portfolio-item.wide > .portfolio-link,
+    .portfolio-item.extra-wide > .portfolio-link,
+    .portfolio-item.tall > .portfolio-link {
         aspect-ratio: 16 / 9;
     }
 
     .portfolio-thumbnail {
-        position: relative;
+        position: absolute;
+        top: 0;
+        left: 0;
         width: 100%;
         height: 100%;
         object-fit: cover;
     }
 
     .portfolio-overlay {
+        position: static;
         opacity: 1;
-        background: rgba(0, 0, 0, 0.1);
+        background: transparent;
+        padding: 15px 0 0 0;
+        pointer-events: auto;
     }
 
     .portfolio-item:hover .portfolio-thumbnail {


### PR DESCRIPTION
- Move portfolio text from overlay to below images on mobile for better readability
- Add red horizontal dividers (2px solid #f00) between portfolio items
- Change .portfolio-item to flex column layout on mobile
- Move aspect-ratio constraint from .portfolio-item to .portfolio-link
- Change .portfolio-overlay to static positioning with transparent background
- Remove border from last portfolio item to avoid trailing line