### PR TITLE
Condense mobile portfolio layout spacing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -632,7 +632,7 @@ h4 {
         display: flex;
         flex-direction: column;
         position: relative;
-        padding-bottom: 30px;
+        padding-bottom: 15px;
         border-bottom: 2px solid #f00;
     }
 
@@ -681,8 +681,18 @@ h4 {
         position: static;
         opacity: 1;
         background: transparent;
-        padding: 15px 0 0 0;
+        padding: 8px 0 0 0;
         pointer-events: auto;
+    }
+
+    .portfolio-overlay h3 {
+        margin: 0 0 5px 0;
+        line-height: 1.2;
+    }
+
+    .portfolio-overlay p {
+        margin: 0;
+        line-height: 1.3;
     }
 
     .portfolio-item:hover .portfolio-thumbnail {


### PR DESCRIPTION
- Reduce space between image and text (15px -> 8px)
- Reduce space between text and red divider (30px -> 15px)
- Tighten line spacing in titles (line-height: 1.2)
- Tighten line spacing in descriptions (line-height: 1.3)
- Remove extra margins from h3 and p elements in overlay