### PR TITLE
Reorganize mobile portfolio layout: title on top, image, then descrip…

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -634,6 +634,7 @@ h4 {
         position: relative;
         padding-bottom: 15px;
         border-bottom: 2px solid #f00;
+        gap: 8px;
     }
 
     /* Remove the border from the last item */
@@ -642,17 +643,55 @@ h4 {
         padding-bottom: 0;
     }
 
-    /* Remove pseudo-element on mobile */
-    .portfolio-item::before {
-        display: none;
+    /* Flatten portfolio-overlay so children can be reordered */
+    .portfolio-overlay {
+        display: contents;
     }
 
-    /* Reset positioning on mobile */
+    /* Title goes first */
+    .portfolio-overlay h3 {
+        order: -3;
+        margin: 0;
+        line-height: 1.2;
+        font-size: 1.2em;
+    }
+
+    /* Image goes second */
     .portfolio-item > .portfolio-link {
+        order: -2;
         position: relative;
         width: 100%;
         aspect-ratio: 16 / 9;
         overflow: hidden;
+        display: block;
+    }
+
+    .portfolio-thumbnail {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    /* Add "View Details" text after image using ::before pseudo-element */
+    .portfolio-item::before {
+        content: "View Details →";
+        order: -1;
+        display: block;
+        text-align: center;
+        color: #f00;
+        font-size: 0.9em;
+        font-weight: 500;
+    }
+
+    /* Description goes last */
+    .portfolio-overlay p {
+        order: 0;
+        margin: 0;
+        line-height: 1.3;
+        font-size: 0.95em;
     }
 
     .portfolio-item.wide,
@@ -666,33 +705,6 @@ h4 {
     .portfolio-item.extra-wide > .portfolio-link,
     .portfolio-item.tall > .portfolio-link {
         aspect-ratio: 16 / 9;
-    }
-
-    .portfolio-thumbnail {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .portfolio-overlay {
-        position: static;
-        opacity: 1;
-        background: transparent;
-        padding: 5px 0 0 0;
-        pointer-events: auto;
-    }
-
-    .portfolio-overlay h3 {
-        margin: 0 0 5px 0;
-        line-height: 1.2;
-    }
-
-    .portfolio-overlay p {
-        margin: 0;
-        line-height: 1.3;
     }
 
     .portfolio-item:hover .portfolio-thumbnail {


### PR DESCRIPTION
…tion

- Title now appears at top of each portfolio item on mobile
- Image in middle with 16:9 aspect ratio
- "View Details →" link text after image in red
- Description text below
- Use CSS flexbox with display: contents and order properties to rearrange elements
- Maintain red dividers between items
- Consistent 8px gap spacing between elements