### PR TITLE
Reorganize mobile portfolio item layout: move title above image

### DIFF
--- a/_layouts/portfolio_item.html
+++ b/_layouts/portfolio_item.html
@@ -37,9 +37,8 @@ layout: default
 {% endif %}
     
 <div class="portfolio-item-page">
-  <div class="portfolio-description">
+  <div class="portfolio-title">
     <h1>{{ page.title }}</h1>
-    {{ content }}
   </div>
 
   <div class="portfolio-image">
@@ -48,7 +47,7 @@ layout: default
          alt="{{ page.title }}"
          data-full-image="{{ page.full_image | default: page.thumbnail }}"
          {% if page.storymap_url %}data-storymap-url="{{ page.storymap_url }}"{% endif %}>
-    
+
     <!-- Instructional text -->
     <div class="image-instruction">
       {% if page.storymap_url %}
@@ -57,6 +56,10 @@ layout: default
         (Click to view full-resolution image)
       {% endif %}
     </div>
+  </div>
+
+  <div class="portfolio-description">
+    {{ content }}
   </div>
 </div>
 
@@ -73,6 +76,11 @@ layout: default
     gap: 40px;
     padding: 40px;
     margin: 0 auto;
+    flex-wrap: wrap;
+  }
+
+  .portfolio-title {
+    flex: 1 1 100%;
   }
 
   .portfolio-description {
@@ -113,12 +121,12 @@ layout: default
     overflow: hidden;
     background-color: rgba(0,0,0,0.9);
   }
-  
+
   #popup-canvas {
     display: block;
     margin: auto;
   }
-  
+
   .close-btn {
     position: absolute;
     top: 15px;
@@ -129,7 +137,7 @@ layout: default
     cursor: pointer;
     z-index: 10000;
   }
-  
+
   .close-btn:hover {
     color: #bbb;
   }
@@ -140,17 +148,24 @@ layout: default
       flex-direction: column;
       align-items: stretch;
       padding: 20px;
+      gap: 0;
     }
 
-    .portfolio-description {
-      order: 2;
-      width: 100%;
-    }
-
-    .portfolio-image {
+    .portfolio-title {
       order: 1;
       width: 100%;
       margin-bottom: 20px;
+    }
+
+    .portfolio-image {
+      order: 2;
+      width: 100%;
+      margin-bottom: 15px;
+    }
+
+    .portfolio-description {
+      order: 3;
+      width: 100%;
     }
 
     .portfolio-image img {


### PR DESCRIPTION
- Separated title, image, and description into distinct divs for better control
- On mobile: title appears first, then image, then description text
- Adjusted spacing: 20px between title and image, 15px between image and description for a cohesive look
- Desktop layout unchanged: title spans full width, description and image side by side