### PR TITLE
Condense mobile portfolio spacing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -632,7 +632,7 @@ h4 {
         display: flex;
         flex-direction: column;
         position: relative;
-        padding-bottom: 30px;
+        padding-bottom: 15px;
         border-bottom: 2px solid #f00;
     }
 
@@ -681,8 +681,16 @@ h4 {
         position: static;
         opacity: 1;
         background: transparent;
-        padding: 15px 0 0 0;
+        padding: 10px 0 0 0;
         pointer-events: auto;
+    }
+
+    .portfolio-overlay h3 {
+        margin: 0 0 5px 0;
+    }
+
+    .portfolio-overlay p {
+        margin: 0;
     }
 
     .portfolio-item:hover .portfolio-thumbnail {


### PR DESCRIPTION
- Reduce image-to-title spacing: 15px → 10px
- Reduce title-to-subtitle spacing: 5px (tightest)
- Reduce subtitle-to-divider spacing: 30px → 15px
- Add explicit margin controls for h3 and p in overlay